### PR TITLE
slackに通知せずコンソールに出力するだけのサブコマンドを追加

### DIFF
--- a/py/crawler.py
+++ b/py/crawler.py
@@ -11,13 +11,6 @@ from config import YOUR_ID, YOUR_PW
 TOP_URL = "https://s3.kingtime.jp/admin"
 DRIVER_PATH = "./drivers/chromedriver"
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--headless", type=bool, required=False, default=True, help="headless mode"
-)
-p = vars(parser.parse_args())
-IS_HEADLESS = p["headless"]
-
 
 # Class
 class Browser:
@@ -54,9 +47,9 @@ class Browser:
 
 
 class Crawler:
-    def __init__(self):
+    def __init__(self, headless):
         options = webdriver.ChromeOptions()
-        if IS_HEADLESS:
+        if headless:
             options.add_argument("--headless")
         self.driver = webdriver.Chrome(executable_path=DRIVER_PATH, options=options)
         self.browser = Browser(self.driver)


### PR DESCRIPTION
# 概要

掲題の通り。コンソールに出力するだけのコマンドを追加しました。

```
$ python run.py console
```

出力内容
```
    残り12営業日: (8/20 日)

    あと94.34h必要: (65.26/160h)

    貯金: 1.26h

    貯金を元に残り営業日の必要勤務時間数を算出すると: 7.52h

    2019-11-14の出勤・定時
        出勤: 10:15
        定時: 19:15
```

## やったこと

* run.pyにargparseの処理を移動しました
* サブコマンド `console` を追加しました
* 既存のrun.pyの挙動を崩さないため、コマンドライン引数なしの場合slack通知の関数を呼ぶよう調整しました
* その他typoなど