### PR TITLE
fix calc_saving_time

### DIFF
--- a/py/scraper.py
+++ b/py/scraper.py
@@ -46,7 +46,8 @@ class Scraper:
         return remain_hours_by_day
 
     def calc_saving_time(self, work_hour, work_count):
-        return work_hour - WORK_HOUR * work_count
+        # work_hourは実労働時間でwork_countは実労働日数+休暇なので、休暇分は減らす
+        return work_hour - WORK_HOUR * (work_count - self.holiday_count)
 
     def get_holiday_count(self):
         holiday_counts = self.soup.find_all("div", class_="holiday_count")


### PR DESCRIPTION
## 概要
- saving_time計算時に、休暇を使っていた場合に計算結果が合わなくなります
- これはwork_countは実労働日数＋休暇になっているのに対し、work_hourには休暇分が足されていなかったためです
  - work_hour（実労働時間） - WORK_HOUR *work_count（実労働日数＋有給etc）

## 変更
- 休暇分を考慮するようにしました