### PR TITLE
cd for symbolic link

### DIFF
--- a/scripts/myrecorder.sh
+++ b/scripts/myrecorder.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname $(realpath "$0"))"
+
 CONFIG_PATH=${HOME}/.kot/config.yaml
 if [ ! -f "$CONFIG_PATH" ]; then
   CONFIG_PATH=${PWD}/config.yaml

--- a/scripts/myrecorder.sh
+++ b/scripts/myrecorder.sh
@@ -27,3 +27,5 @@ if [ -z "${MESSAGE}" ]; then
 else
   docker compose run --rm app kot myrecorder ${CMD} --no-yes  --message "${MESSAGE}" --browser-kind remote
 fi
+
+docker compose down

--- a/scripts/scrapekot.sh
+++ b/scripts/scrapekot.sh
@@ -19,3 +19,4 @@ else
 fi
 
 docker compose run --rm app kot scrape ${CONSOLE} --browser-kind remote
+docker compose down

--- a/scripts/scrapekot.sh
+++ b/scripts/scrapekot.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname $(realpath "$0"))"
+
 CONFIG_PATH=${HOME}/.kot/config.yaml
 if [ ! -f "$CONFIG_PATH" ]; then
   CONFIG_PATH=${PWD}/config.yaml


### PR DESCRIPTION
シンボリックリンクを以下のように貼った際に、docker composeが見つからなくなってしまっていたので、script実行時にリポジトリのディレクトリに移動するようにしました
```
ln -s /path_to_repo/scripts/scrapekot.sh /usr/local/bin/kot
```

そして seleniumのコンテナがたちっぱなしだとハングするので毎回落とすようにする